### PR TITLE
Crash fix-RN 0.65.1

### DIFF
--- a/src/views/BottomTabBar.js
+++ b/src/views/BottomTabBar.js
@@ -34,6 +34,7 @@ export type TabBarOptions = {
   labelPosition?: LabelPosition,
   adaptive?: boolean,
   style: any,
+  keyboardDidShowListener: any,
 };
 
 type Props = TabBarOptions & {
@@ -113,23 +114,21 @@ class TabBarBottom extends React.Component<Props, State> {
   };
 
   componentDidMount() {
-    if (Platform.OS === 'ios') {
-      Keyboard.addListener('keyboardWillShow', this._handleKeyboardShow);
-      Keyboard.addListener('keyboardWillHide', this._handleKeyboardHide);
-    } else {
-      Keyboard.addListener('keyboardDidShow', this._handleKeyboardShow);
-      Keyboard.addListener('keyboardDidHide', this._handleKeyboardHide);
-    }
+    // RN 0.65.1 crash fix
+    this.keyboardDidShowListener = Keyboard.addListener(
+      'keyboardDidShow',
+      this._handleKeyboardShow,
+    );
+    this.keyboardDidHideListener = Keyboard.addListener(
+      'keyboardDidHide',
+      this._handleKeyboardHide,
+    );
   }
 
   componentWillUnmount() {
-    if (Platform.OS === 'ios') {
-      Keyboard.removeListener('keyboardWillShow', this._handleKeyboardShow);
-      Keyboard.removeListener('keyboardWillHide', this._handleKeyboardHide);
-    } else {
-      Keyboard.removeListener('keyboardDidShow', this._handleKeyboardShow);
-      Keyboard.removeListener('keyboardDidHide', this._handleKeyboardHide);
-    }
+     // RN 0.65.1 crash fix
+    this.keyboardDidShowListener.remove();
+    this.keyboardDidHideListener.remove();
   }
 
   _handleKeyboardShow = () =>


### PR DESCRIPTION
For RN 0.65.1 version app is crashing because of the keyboard's old API. 

<img width="888" alt="Screenshot 2021-09-24 at 12 42 15" src="https://user-images.githubusercontent.com/28752577/134669372-21f926e1-4af9-4a6d-a8b5-56c722b07817.png">

BottomTabBar.js - Keyboard API is updated.

